### PR TITLE
Update @adhd/transform export structure

### DIFF
--- a/packages/data/vite.config.ts
+++ b/packages/data/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
       fileName: 'index',
       // Change this to the formats you want to support.
       // Don't forget to update your package.json as well.
-      formats: ['es', 'cjs'],
+      formats: ['es', 'cjs', 'umd'],
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.

--- a/packages/query/src/lib/filters.ts
+++ b/packages/query/src/lib/filters.ts
@@ -1,5 +1,4 @@
-import _ from "@adhd/transform";
-
+import { Transform as _ } from "@adhd/transform";
 export const partialApply = (fn: ((...args: any[]) => any), ...cache: undefined[]) => (...args: any[]) => {
   const all = cache.concat(args);
   return all.length >= fn.length ? fn(...all) : partialApply(fn, ...all);
@@ -58,8 +57,8 @@ export const operators: Record<string, FilterPartial> = {
   _contained_in: partialApply(isContainedIn),
   _has_key: partialApply(hasKey),
   _has_keys_any: partialApply(hasKeysAny),
-  _is_null: partialApply(isNull),
   _has_keys_all: partialApply(hasKeysAll),
+  _is_null: partialApply(isNull),
 };
 
 export const logicalOperators: Record<string, FilterPartial> = {

--- a/packages/query/src/lib/operators.ts
+++ b/packages/query/src/lib/operators.ts
@@ -1,58 +1,57 @@
 export const Operators = [
-    { name: 'equals', value: '$eq', graphqlOp: '_eq' },
-    { name: 'not equals', value: '$ne', graphqlOp: '_neq' },
-    { name: 'in', value: '$in', graphqlOp: '_in', defaultValue: '[]' },
-    { name: 'not in', value: '$nin', graphqlOp: '_nin', defaultValue: '[]' },
-    { name: '>', value: '$gt', graphqlOp: '_gt' },
-    { name: '<', value: '$lt', graphqlOp: '_lt' },
-    { name: '>=', value: '$gte', graphqlOp: '_gte' },
-    { name: '<=', value: '$lte', graphqlOp: '_lte' },
-    { name: 'like', value: '$like', graphqlOp: '_like', defaultValue: '%%' },
-    {
-      name: 'not like',
-      value: '$nlike',
-      graphqlOp: '_nlike',
-      defaultValue: '%%',
-    },
-    {
-      name: 'like (case-insensitive)',
-      value: '$ilike',
-      graphqlOp: '_ilike',
-      defaultValue: '%%',
-    },
-    {
-      name: 'not like (case-insensitive)',
-      value: '$nilike',
-      graphqlOp: '_nilike',
-      defaultValue: '%%',
-    },
-    { name: 'similar', value: '$similar', graphqlOp: '_similar' },
-    { name: 'not similar', value: '$nsimilar', graphqlOp: '_nsimilar' },
-  
-    {
-      name: '~',
-      value: '$regex',
-      graphqlOp: '_regex',
-    },
-    {
-      name: '~*',
-      value: '$iregex',
-      graphqlOp: '_iregex',
-    },
-    {
-      name: '!~',
-      value: '$nregex',
-      graphqlOp: '_nregex',
-    },
-    {
-      name: '!~*',
-      value: '$niregex',
-      graphqlOp: '_niregex',
-    },
-  ];
+  { name: 'equals', value: '$eq', graphqlOp: '_eq' },
+  { name: 'not equals', value: '$ne', graphqlOp: '_neq' },
+  { name: 'in', value: '$in', graphqlOp: '_in', defaultValue: '[]' },
+  { name: 'not in', value: '$nin', graphqlOp: '_nin', defaultValue: '[]' },
+  { name: '>', value: '$gt', graphqlOp: '_gt' },
+  { name: '<', value: '$lt', graphqlOp: '_lt' },
+  { name: '>=', value: '$gte', graphqlOp: '_gte' },
+  { name: '<=', value: '$lte', graphqlOp: '_lte' },
+  { name: 'like', value: '$like', graphqlOp: '_like', defaultValue: '%%' },
+  {
+    name: 'not like',
+    value: '$nlike',
+    graphqlOp: '_nlike',
+    defaultValue: '%%',
+  },
+  {
+    name: 'like (case-insensitive)',
+    value: '$ilike',
+    graphqlOp: '_ilike',
+    defaultValue: '%%',
+  },
+  {
+    name: 'not like (case-insensitive)',
+    value: '$nilike',
+    graphqlOp: '_nilike',
+    defaultValue: '%%',
+  },
+  { name: 'similar', value: '$similar', graphqlOp: '_similar' },
+  { name: 'not similar', value: '$nsimilar', graphqlOp: '_nsimilar' },
+  {
+    name: '~',
+    value: '$regex',
+    graphqlOp: '_regex',
+  },
+  {
+    name: '~*',
+    value: '$iregex',
+    graphqlOp: '_iregex',
+  },
+  {
+    name: '!~',
+    value: '$nregex',
+    graphqlOp: '_nregex',
+  },
+  {
+    name: '!~*',
+    value: '$niregex',
+    graphqlOp: '_niregex',
+  },
+];
 
-  export type OrderByOperation = {
-    key: string;
-    dir: "asc" | "desc";
-    nulls: "first"| "last";
-  }
+export type OrderByOperation = {
+  key: string;
+  dir: "asc" | "desc";
+  nulls: "first" | "last";
+}

--- a/packages/query/src/lib/parser.ts
+++ b/packages/query/src/lib/parser.ts
@@ -1,4 +1,4 @@
-import _ from '@adhd/transform';
+import { Transform as _ } from '@adhd/transform';
 import { BooleanExpression, OrderByExpression } from "./expressions";
 import { operators } from './filters';
 import { OrderByOperation } from "./operators";

--- a/packages/query/src/lib/query.ts
+++ b/packages/query/src/lib/query.ts
@@ -1,4 +1,4 @@
-import _ from '@adhd/transform';
+import { Transform as _ } from '@adhd/transform';
 import { OrderByExpression, QueryExpression } from './expressions';
 import { parseOrderBy, parseWhere } from './parser';
 
@@ -118,8 +118,8 @@ export class Query implements QueryType {
 }
 
 export class DataView {
-  data?: any[];
-  dataview: any;
+  data: any[] = [];
+  dataview: any[] = [];
   query: Query;
   dirty: any;
   logging: boolean;

--- a/packages/query/vite.config.ts
+++ b/packages/query/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
       fileName: 'index',
       // Change this to the formats you want to support.
       // Don't forget to update your package.json as well.
-      formats: ['es', 'cjs'],
+      formats: ['es', 'cjs', 'umd'],
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.

--- a/packages/react-hooks/src/lib/use-file-download/index.ts
+++ b/packages/react-hooks/src/lib/use-file-download/index.ts
@@ -2,7 +2,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { compressBlob } from './compression';
 import { encryptBlob } from './encryption';
-
 export type FileType = 'json' | 'csv' | 'excel';
 
 export interface ValidationOptions {
@@ -110,7 +109,8 @@ export const useFileDownload = ({
             const workerInstance = new Worker(new URL('./worker.ts', import.meta.url));
 
             // Set up message handler
-            workerInstance.onmessage = (event) => {
+            // WorkerMessage from worker is typed different
+            workerInstance.onmessage = (event: MessageEvent<any>) => {
                 const { status, progress, result, error } = event.data;
 
                 if (status === 'progress') {

--- a/packages/react-hooks/src/lib/use-file-download/index.ts
+++ b/packages/react-hooks/src/lib/use-file-download/index.ts
@@ -98,12 +98,38 @@ export const useFileDownload = ({
     const cache = useMemo(() => new Map<string, Blob>(), []);
 
     // Optional Web Worker for large datasets
+    // const worker = useMemo(() => {
+    //     if (typeof Worker !== 'undefined' && new Blob([JSON.stringify(data)]).size > MAX_FILE_SIZE) {
+    //         return new Worker(new URL('./download.worker.ts', import.meta.url));
+    //     }
+    //     return null;
+    // }, [data]);
+
     const worker = useMemo(() => {
         if (typeof Worker !== 'undefined' && new Blob([JSON.stringify(data)]).size > MAX_FILE_SIZE) {
-            return new Worker(new URL('./download.worker.ts', import.meta.url));
+            const workerInstance = new Worker(new URL('./worker.ts', import.meta.url));
+
+            // Set up message handler
+            workerInstance.onmessage = (event) => {
+                const { status, progress, result, error } = event.data;
+
+                if (status === 'progress') {
+                    setDownloadState(prev => ({ ...prev, progress, status: 'processing' }));
+                    options.onProgress?.(progress);
+                } else if (status === 'error') {
+                    setDownloadState({ status: 'error', progress: 0, error: new Error(error) });
+                    options.onError?.(new Error(error));
+                } else if (status === 'complete') {
+                    const blob = new Blob([result.data], { type: result.type });
+                    cache.set(result.cacheKey, blob);
+                    processDownload(blob, result.fileType);
+                }
+            };
+
+            return workerInstance;
         }
         return null;
-    }, [data]);
+    }, [data, options.onProgress, options.onError]);
 
     // Cleanup function
     useEffect(() => {
@@ -163,6 +189,7 @@ export const useFileDownload = ({
         return csvRows.join('\n');
     }, []);
 
+    // Async await for queueing
     const processLargeData = useCallback(async (data: any[], fileType: FileType): Promise<Blob> => {
         const chunks: any[][] = [];
         const totalChunks = Math.ceil(data.length / CHUNK_SIZE);
@@ -211,7 +238,17 @@ export const useFileDownload = ({
             } else {
                 setDownloadState(prev => ({ ...prev, status: 'processing' }));
 
-                if (Array.isArray(data) && data.length > CHUNK_SIZE) {
+                if (Array.isArray(data) && data.length > CHUNK_SIZE && worker && fileType != 'excel') {
+                    // Use Web Worker for large datasets
+                    worker.postMessage({
+                        data,
+                        fileType,
+                        options,
+                        cacheKey
+                    });
+                    // The worker will handle the rest through its message handler
+                    return;
+                } else if (Array.isArray(data) && data.length > CHUNK_SIZE) {
                     blob = await processLargeData(data, fileType);
                 } else {
                     setDownloadState(prev => ({ ...prev, progress: 90 }));
@@ -290,7 +327,34 @@ export const useFileDownload = ({
             options.onError?.(errorObject);
             throw errorObject;
         }
-    }, [data, fileName, options, cache, processLargeData, processChunk]);
+    }, [data, fileName, options, cache, processLargeData, processChunk, worker]);
+
+    // Add this helper function to handle the final download steps
+    const processDownload = async (blob: Blob, fileType: FileType) => {
+        // Post-processing phase (90-95%)
+        setDownloadState(prev => ({ ...prev, progress: 92, status: 'processing' }));
+        options.onProgress?.(92);
+
+        // Compression and encryption phases...
+        // (Keep your existing compression and encryption logic here)
+
+        // Create and trigger download
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${fileName}.${fileType}`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+
+        const result = { url, size: blob.size };
+
+        setDownloadState({ status: 'success', progress: 100, error: null });
+        options.onSuccess?.(result);
+
+        return result;
+    };
 
     return {
         downloadFile,

--- a/packages/react-hooks/src/lib/use-file-download/worker.ts
+++ b/packages/react-hooks/src/lib/use-file-download/worker.ts
@@ -1,0 +1,135 @@
+// download.worker.ts
+
+interface WorkerMessage {
+    data: any[];
+    fileType: 'json' | 'csv' | 'excel';
+    options: any;
+    cacheKey: string;
+}
+
+const CHUNK_SIZE = 1000;
+
+self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
+    const { data, fileType, options, cacheKey } = event.data;
+
+    try {
+        const result = await processLargeData(data, fileType, options);
+        self.postMessage({
+            status: 'complete',
+            result: {
+                data: result.data,
+                type: result.type,
+                fileType,
+                cacheKey
+            }
+        });
+    } catch (error) {
+        self.postMessage({
+            status: 'error',
+            error: error instanceof Error ? error.message : 'Processing failed'
+        });
+    }
+};
+
+async function processLargeData(
+    data: any[],
+    fileType: 'json' | 'csv' | 'excel',
+    options: any
+) {
+    const chunks: any[][] = [];
+    const totalChunks = Math.ceil(data.length / CHUNK_SIZE);
+
+    // Split data into chunks
+    for (let i = 0; i < data.length; i += CHUNK_SIZE) {
+        chunks.push(data.slice(i, i + CHUNK_SIZE));
+    }
+
+    let processedChunks: any[] = [];
+
+    // Process each chunk
+    for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+        const processedChunk = await processChunk(chunk, fileType, options);
+        processedChunks.push(processedChunk);
+
+        // Report progress back to main thread
+        const progress = Math.floor((i / totalChunks) * 90);
+        self.postMessage({ status: 'progress', progress });
+    }
+
+    // Combine processed chunks
+    return combineChunks(processedChunks, fileType);
+}
+
+async function processChunk(
+    chunk: any[],
+    fileType: 'json' | 'csv' | 'excel',
+    options: any
+) {
+    switch (fileType) {
+        case 'csv':
+            return convertToCSV(chunk, options.csv);
+        case 'excel':
+            // Note: XLSX operations should be handled in main thread
+            // as Web Workers don't have direct access to external modules
+            return JSON.stringify(chunk);
+        default:
+            return JSON.stringify(chunk, null, 2);
+    }
+}
+
+function convertToCSV(data: any[], csvOptions?: any): string {
+    if (!Array.isArray(data) || !data.length) return '';
+
+    const delimiter = csvOptions?.delimiter || ',';
+    const useQuotes = csvOptions?.quotes !== false;
+    const includeHeader = csvOptions?.header !== false;
+
+    const headers = Object.keys(data[0]);
+    const csvRows = [];
+
+    if (includeHeader) {
+        csvRows.push(headers.join(delimiter));
+    }
+
+    csvRows.push(
+        ...data.map(row =>
+            headers.map(header => {
+                const cell = row[header];
+                const value = typeof cell === 'object' ? JSON.stringify(cell) : cell;
+                return useQuotes ? `"${String(value).replace(/"/g, '""')}"` : String(value);
+            }).join(delimiter)
+        )
+    );
+
+    return csvRows.join('\n');
+}
+
+function combineChunks(chunks: any[], fileType: 'json' | 'csv' | 'excel') {
+    let type: string;
+    let data: any;
+
+    switch (fileType) {
+        case 'csv':
+            type = 'text/csv;charset=utf-8;';
+            // For CSV, we need to keep only one header
+            data = chunks[0].split('\n')[0] + '\n' +
+                chunks.map(chunk =>
+                    chunk.split('\n').slice(1).join('\n')
+                ).join('\n');
+            break;
+        case 'excel':
+            type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+            data = JSON.parse('[' + chunks.join(',') + ']');
+            break;
+        default:
+            type = 'application/json;charset=utf-8;';
+            data = '[' + chunks.join(',') + ']';
+    }
+
+    return { data, type };
+}
+
+// Required for TypeScript to recognize this as a module
+export { };
+

--- a/packages/react-hooks/src/lib/use-file-download/worker.ts
+++ b/packages/react-hooks/src/lib/use-file-download/worker.ts
@@ -1,6 +1,6 @@
 // download.worker.ts
 
-interface WorkerMessage {
+export type WorkerMessage = {
     data: any[];
     fileType: 'json' | 'csv' | 'excel';
     options: any;
@@ -131,5 +131,5 @@ function combineChunks(chunks: any[], fileType: 'json' | 'csv' | 'excel') {
 }
 
 // Required for TypeScript to recognize this as a module
-export { };
+// export { };
 

--- a/packages/react-hooks/vite.config.ts
+++ b/packages/react-hooks/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
       fileName: 'index',
       // Change this to the formats you want to support.
       // Don't forget to update your package.json as well.
-      formats: ['es', 'cjs'],
+      formats: ['es', 'cjs', 'umd'],
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.

--- a/packages/storybook/vite.config.ts
+++ b/packages/storybook/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   // See: https://vitejs.dev/guide/build.html#library-mode
   build: {
     sourcemap: 'inline',
-    outDir: '../../dist/packages',
+    outDir: '../../dist/packages/storybook',
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -10,8 +10,7 @@ export const Stats = _Stats;
 export const Collections = _Collections;
 export const Filters = _Filters;
 export const Texts = _Texts;
-
-export default {
+export const Transform = {
   ..._Functions,
   ..._Objects,
   ..._Stats,
@@ -19,3 +18,11 @@ export default {
   ..._Filters,
   ..._Texts,
 };
+// export default {
+//   ..._Functions,
+//   ..._Objects,
+//   ..._Stats,
+//   ..._Collections,
+//   ..._Filters,
+//   ..._Texts,
+// };

--- a/packages/transform/vite.config.ts
+++ b/packages/transform/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
       fileName: 'index',
       // Change this to the formats you want to support.
       // Don't forget to update your package.json as well.
-      formats: ['es', 'cjs'],
+      formats: ['es', 'cjs', 'umd'],
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.


### PR DESCRIPTION
Removes the default export and updates the related imports

# 1: Modify transform module for build compat

Removes
`import _ from '@adhd/transform'`

Replaces with
`import { Transform as _ } from '@adhd/transform'`

Purpose
Improved build compatibility

# 2: Attempt to correct web worker usage in react-hooks for use-file-download

There was a referenced worker.js file that didn't exist

# 3: Output UMD builds for standalone web / cdn build